### PR TITLE
Enable scratch buffer completions

### DIFF
--- a/jade-repl.el
+++ b/jade-repl.el
@@ -346,8 +346,14 @@ See `company-backends' for more info about COMMAND and ARG."
 (defun jade-repl-get-completions (arg callback)
   "Get the completion list matching the prefix ARG.
 Evaluate CALLBACK with the completion candidates."
-  (let ((expression (buffer-substring-no-properties jade-repl-input-start-marker
-                                                    (point-max-marker))))
+  (let ((expression (buffer-substring-no-properties
+                     (let ((bol (line-beginning-position))
+                           (prev-delimiter (1+ (save-excursion
+                                                 (re-search-backward "[([:space:]]" nil t)))))
+                       (if prev-delimiter
+                           (max bol prev-delimiter)
+                         bol))
+                     (point))))
     (jade-backend-get-completions (jade-backend) expression arg callback)))
 
 (defun jade-repl--complete-or-indent ()
@@ -359,7 +365,8 @@ Evaluate CALLBACK with the completion candidates."
 
 (defun jade-repl-company-prefix ()
   "Prefix for company."
-  (and (eq major-mode 'jade-repl-mode)
+  (and (or (eq major-mode 'jade-repl-mode)
+           (bound-and-true-p jade-interaction-mode))
        (or (company-grab-symbol-cons "\\." 1)
            'stop)))
 

--- a/jade-scratch.el
+++ b/jade-scratch.el
@@ -56,10 +56,10 @@ If there is no current connection, throw an error."
 (defun jade-scratch-setup-buffer (buffer connection)
   "Setup the scratch BUFFER for  CONNECTION."
   (with-current-buffer buffer
-    ;; TODO: enable completion like in the REPL
     (js2-mode)
     (jade-interaction-mode)
     (setq-local jade-connection connection)
+    (add-to-list 'company-backends 'company-jade-repl)
     (jade-scratch-insert-welcome-message)))
 
 (defun jade-scratch-insert-welcome-message ()


### PR DESCRIPTION
Enable completions in the scratch buffer by using the company-jade-repl backend.

I've changed the expression logic for the completions since the current completions only seemed to work for lines with only one symbol (for: `var x = "test".substr(0,2);` f.ex. the completions shown after `"test".` were not correct).